### PR TITLE
Folder management with bucket queue

### DIFF
--- a/src/filemgmt.js
+++ b/src/filemgmt.js
@@ -32,7 +32,7 @@ function shouldBeCached(filePath) {
     return true;
 }
 
-// Works for struct too
+// Works for structs and folders too
 exports.checkFileExists = function(filePath) {
     if (!shouldBeCached(filePath)) {
         if (fs.existsSync(config.resolvePath(filePath))) {
@@ -49,7 +49,7 @@ exports.checkFileExists = function(filePath) {
             return Promise.reject();
         }
 
-        return Promise.resolve();
+        return Promise.resolve(request.fileType); // Request is resolved with file type (eg. if it's a folder)
     });
 };
 
@@ -99,7 +99,7 @@ exports.saveStruct = function(structInstance) {
     }
 };
 
-// Works for struct too
+// Works for structs and folders too
 exports.deleteFile = function(filePath) {
     var fileSize = fs.statSync(config.resolvePath(filePath)).size;
 
@@ -107,5 +107,13 @@ exports.deleteFile = function(filePath) {
 
     if (shouldBeCached(filePath)) {
         bucketQueue.deleteFile(filePath, fileSize);
+    }
+};
+
+exports.createFolder = function (filePath) {
+    mkdirp.sync(path.dirname(config.resolvePath(filePath)));
+
+    if (shouldBeCached(filePath)) {
+        bucketQueue.cacheFolder(filePath);
     }
 };

--- a/tests/filemgmt.test.js
+++ b/tests/filemgmt.test.js
@@ -42,6 +42,7 @@ console.log(bucketQueue.mergeQueues());
 
 console.log("Tx file 2 to fulfil request");
 bucketQueue.initRequest(bucketQueue.mergeQueues()[1]?.timestamp, {
+    fileType: "file",
     bytesTotal: 100
 });
 
@@ -53,3 +54,26 @@ bucketQueue.txRequestData(
 
 console.log("Get queue");
 console.log(bucketQueue.mergeQueues());
+
+console.log("Create empty folder and child folder");
+fileMgmt.createFolder("shared:empty/subfolder");
+
+console.log("Get queue");
+console.log(bucketQueue.mergeQueues());
+
+console.log("Check existence of folder");
+fileMgmt.checkFileExists("shared:empty").then(function(type) {
+    console.log("Checked existence");
+    console.log(type);
+}).catch(function() {
+    console.error("Does not exist");
+});
+
+console.log("Get queue");
+console.log(bucketQueue.mergeQueues());
+
+console.log("Respond existence");
+bucketQueue.initRequest(bucketQueue.mergeQueues()[2]?.timestamp, {
+    fileType: "folder",
+    bytesTotal: 0
+});

--- a/tests/filemgmt.test.js
+++ b/tests/filemgmt.test.js
@@ -20,6 +20,7 @@ fileMgmt.loadFile("shared:test1.txt").then(function(data) {
     console.log(data);
 });
 
+console.log("Save file 2");
 fileMgmt.saveFile("shared:test2.txt", "2".repeat(100));
 
 console.log("Get queue");


### PR DESCRIPTION
Before this change, the bucket queue could only create folders when files were created, since the system would automatically create parent folders for subfoldered files (similar to how git does it). However, this change allows users to softly create folders which contain no files (if the folder existed beforehand because of a resolved file, then nothing will happen).

Tests have been written in `tests/filemgmt.js`.